### PR TITLE
fix: end-of-range-class-and-styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - new: add `prevButtonClassName` prop to `Header` component.
 - new: add `nextButtonClassName` prop to `Header` component.
 - fix: header next button aria-label wording fixed.
+- fix: in range picker, when not selecting the second date, the end of range class and styles should not be applied.
 
 ### version 1.1.4
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "headless-react-datepicker",
   "private": false,
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A headless, highly customizable, multi-calendar date picker component for React. It supports various calendars and locales.",
   "author": "Sepehr Karimi <karimi.sepehr2@gmail.com>",
   "type": "module",

--- a/src/components/daySlots/DaySlots.tsx
+++ b/src/components/daySlots/DaySlots.tsx
@@ -224,6 +224,7 @@ function DaySlots(props: TDaySlots) {
 
         const isEndOfRange =
           Array.isArray(selectedDay) &&
+          selectedDay.length === 2 &&
           isSameDay(date, selectedDay?.[selectedDay?.length - 1]);
 
         const isDisabled =


### PR DESCRIPTION
in range picker, when not selecting the second date, the end of range class and styles should not be applied.