### PR TITLE
fix: preserve backward-compatible navigation and style imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### version 2.0.1
+
+- fix: `goToNextMonth` and `goToPrevMonth` can be passed directly to React `onClick` handlers again; the optional `step` parameter now ignores click events and defaults to `1`.
+
 ### version 2.0.0
 
 **Highlights**
@@ -26,7 +30,7 @@
 **Chores**
 
 - chore: migrate the package manager from yarn to pnpm.
-- chore: the stylesheet can now be imported as `headless-react-datepicker/styles.css` (the existing `headless-react-datepicker/dist/styles.css` path keeps working).
+- chore: the stylesheet can now be imported as `headless-react-datepicker/styles.css`; the legacy `headless-react-datepicker/dist/styles.css` import remains supported for backward compatibility, but is deprecated.
 - perf: the `@js-temporal/polyfill` is no longer inlined into the build — it stays an external dependency that's resolved (and de-duplicated) from your `node_modules`. This drops the published runtime bundle size without losing any feature.
 - perf: bumped the compile `target` from ES5 to ES2019, removing the iterator/spread helper boilerplate from the output.
 

--- a/README.md
+++ b/README.md
@@ -788,9 +788,16 @@ context, so you can customize and build your own components easily.
 import { useDatePickerContext } from "headless-react-datepicker";
 
 const MyCustomAwesomeHeader = () => {
-  const { goToCurrentMonth, yearInTheCalendar } = useDatePickerContext();
+  const { goToPrevMonth, goToCurrentMonth, yearInTheCalendar } =
+    useDatePickerContext();
 
-  return <div onClick={goToCurrentMonth}>{yearInTheCalendar}</div>;
+  return (
+    <>
+      <button onClick={goToPrevMonth}>Previous month</button>
+      <button onClick={() => goToPrevMonth(2)}>Previous 2 months</button>
+      <div onClick={goToCurrentMonth}>{yearInTheCalendar}</div>
+    </>
+  );
 };
 ```
 
@@ -798,8 +805,8 @@ const MyCustomAwesomeHeader = () => {
 
 | Name                      | Type                                                                                   | Description                                                                                                |
 | ------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| goToNextMonth             | (step?: number) => void                                                                | Navigate to the next month (`step` months forward, default `1`).                                           |
-| goToPrevMonth             | (step?: number) => void                                                                | Navigate to the previous month (`step` months back, default `1`).                                          |
+| goToNextMonth             | (step?: number \| React.SyntheticEvent) => void                                        | Navigate to the next month (`step` months forward, default `1`). Can be passed directly to `onClick`.      |
+| goToPrevMonth             | (step?: number \| React.SyntheticEvent) => void                                        | Navigate to the previous month (`step` months back, default `1`). Can be passed directly to `onClick`.     |
 | goToDate                  | (date: Date) => void                                                                   | Navigate to a specific date.                                                                               |
 | goToCurrentMonth          | () => void                                                                             | Navigate to the current month.                                                                             |
 | goToMonth                 | (month: number) => void                                                                | Go to a month (in the selected calendar).                                                                  |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headless-react-datepicker",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A headless, highly customizable, multi-calendar date picker component for React. It supports various calendars and locales.",
   "author": "Sepehr Karimi <karimi.sepehr2@gmail.com>",
   "type": "module",
@@ -68,6 +68,7 @@
   "scripts": {
     "dev": "vite",
     "build-vite": "tsc && vite build",
+    "type-check": "tsc --noEmit",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
@@ -122,7 +123,7 @@
     "storybook-addon-deep-controls": "^0.10.0",
     "timezone-mock": "^1.3.6",
     "tslib": "^2.6.2",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^5.0.8",
     "vitest": "^1.6.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 10.4.5(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react-vite':
         specifier: 10.4.5
-        version: 10.4.5(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@5.4.21(@types/node@20.19.43)(terser@5.48.0))
+        version: 10.4.5(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@5.4.21(@types/node@20.19.43)(terser@5.48.0))
       '@testing-library/dom':
         specifier: ^10.2.0
         version: 10.4.1
@@ -65,10 +65,10 @@ importers:
         version: 6.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.14.0
-        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3)
       '@typescript-eslint/parser':
         specifier: ^6.14.0
-        version: 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+        version: 6.21.0(eslint@8.57.1)(typescript@6.0.3)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
         version: 4.7.0(vite@5.4.21(@types/node@20.19.43)(terser@5.48.0))
@@ -89,7 +89,7 @@ importers:
         version: 0.4.26(eslint@8.57.1)
       eslint-plugin-storybook:
         specifier: 10.4.5
-        version: 10.4.5(eslint@8.57.1)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        version: 10.4.5(eslint@8.57.1)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       jsdom:
         specifier: ^24.1.0
         version: 24.1.3
@@ -110,7 +110,7 @@ importers:
         version: 4.0.2(postcss@8.5.15)
       rollup-plugin-typescript2:
         specifier: ^0.36.0
-        version: 0.36.0(rollup@4.62.0)(typescript@5.9.3)
+        version: 0.36.0(rollup@4.62.0)(typescript@6.0.3)
       storybook:
         specifier: 10.4.5
         version: 10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -124,8 +124,8 @@ importers:
         specifier: ^2.6.2
         version: 2.8.1
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^5.0.8
         version: 5.4.21(@types/node@20.19.43)(terser@5.48.0)
@@ -2912,8 +2912,8 @@ packages:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3378,13 +3378,13 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.27.10
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@5.4.21(@types/node@20.19.43)(terser@5.48.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@5.4.21(@types/node@20.19.43)(terser@5.48.0))':
     dependencies:
       glob: 13.0.6
-      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
       vite: 5.4.21(@types/node@20.19.43)(terser@5.48.0)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -3751,12 +3751,12 @@ snapshots:
       '@types/react': 18.3.31
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
 
-  '@storybook/react-vite@10.4.5(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@5.4.21(@types/node@20.19.43)(terser@5.48.0))':
+  '@storybook/react-vite@10.4.5(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@5.4.21(@types/node@20.19.43)(terser@5.48.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@5.4.21(@types/node@20.19.43)(terser@5.48.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@5.4.21(@types/node@20.19.43)(terser@5.48.0))
       '@rollup/pluginutils': 5.4.0(rollup@4.62.0)
       '@storybook/builder-vite': 10.4.5(esbuild@0.21.5)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.21(@types/node@20.19.43)(terser@5.48.0))
-      '@storybook/react': 10.4.5(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+      '@storybook/react': 10.4.5(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       empathic: 2.0.1
       magic-string: 0.30.21
       react: 18.3.1
@@ -3775,19 +3775,19 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.4.5(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
+  '@storybook/react@10.4.5(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/react-dom-shim': 10.4.5(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-docgen: 8.0.3
-      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 18.3.1(react@18.3.1)
       storybook: 10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.31
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -3912,13 +3912,13 @@ snapshots:
 
   '@types/tough-cookie@4.0.5': {}
 
-  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.4.3
       eslint: 8.57.1
@@ -3926,31 +3926,31 @@ snapshots:
       ignore: 5.3.2
       natural-compare: 1.4.0
       semver: 7.8.4
-      ts-api-utils: 1.4.3(typescript@5.9.3)
+      ts-api-utils: 1.4.3(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.4.3
       eslint: 8.57.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.61.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.61.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.61.0
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -3964,19 +3964,19 @@ snapshots:
       '@typescript-eslint/types': 8.61.0
       '@typescript-eslint/visitor-keys': 8.61.0
 
-  '@typescript-eslint/tsconfig-utils@8.61.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.61.0(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@6.0.3)
       debug: 4.4.3
       eslint: 8.57.1
-      ts-api-utils: 1.4.3(typescript@5.9.3)
+      ts-api-utils: 1.4.3(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -3984,7 +3984,7 @@ snapshots:
 
   '@typescript-eslint/types@8.61.0': {}
 
-  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
@@ -3993,49 +3993,49 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.8.4
-      ts-api-utils: 1.4.3(typescript@5.9.3)
+      ts-api-utils: 1.4.3(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.61.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.61.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.61.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.61.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.61.0
       '@typescript-eslint/visitor-keys': 8.61.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.4
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@6.0.3)
       eslint: 8.57.1
       semver: 7.8.4
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.61.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.61.0(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 8.61.0
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
       eslint: 8.57.1
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4518,9 +4518,9 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  eslint-plugin-storybook@10.4.5(eslint@8.57.1)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3):
+  eslint-plugin-storybook@10.4.5(eslint@8.57.1)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/utils': 8.61.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@8.57.1)(typescript@6.0.3)
       eslint: 8.57.1
       storybook: 10.4.5(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
@@ -5487,9 +5487,9 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  react-docgen-typescript@2.4.0(typescript@5.9.3):
+  react-docgen-typescript@2.4.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   react-docgen@8.0.3:
     dependencies:
@@ -5578,7 +5578,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  rollup-plugin-typescript2@0.36.0(rollup@4.62.0)(typescript@5.9.3):
+  rollup-plugin-typescript2@0.36.0(rollup@4.62.0)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       find-cache-dir: 3.3.2
@@ -5586,7 +5586,7 @@ snapshots:
       rollup: 4.62.0
       semver: 7.8.4
       tslib: 2.8.1
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   rollup-pluginutils@2.8.2:
     dependencies:
@@ -5814,13 +5814,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  ts-api-utils@1.4.3(typescript@5.9.3):
+  ts-api-utils@1.4.3(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  ts-api-utils@2.5.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   ts-dedent@2.3.0: {}
 
@@ -5840,7 +5840,7 @@ snapshots:
 
   type-fest@0.20.2: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   ufo@1.6.4: {}
 

--- a/src/DatePickerProvider.test.tsx
+++ b/src/DatePickerProvider.test.tsx
@@ -15,7 +15,22 @@ const renderProvider = (props: any = {}) =>
     wrapper: createWrapper(props),
   });
 
+const DirectNavigationButtonUsage = () => {
+  const { goToNextMonth, goToPrevMonth } = useDatePickerContext();
+
+  return (
+    <>
+      <button onClick={goToPrevMonth}>Previous</button>
+      <button onClick={goToNextMonth}>Next</button>
+    </>
+  );
+};
+
 describe("DatePickerProvider", () => {
+  it("allows month navigation functions to be passed directly to onClick", () => {
+    expect(DirectNavigationButtonUsage).toBeDefined();
+  });
+
   describe("initial value", () => {
     it("uses a single initialValue for both selection and displayed month", () => {
       const { result } = renderProvider({
@@ -77,12 +92,30 @@ describe("DatePickerProvider", () => {
       expect(result.current.monthInTheCalendar).toBe(3);
     });
 
+    it("goToNextMonth ignores React click events for direct onClick usage", () => {
+      const { result } = renderProvider({
+        defaultStartDate: new Date("2024-01-15T00:00:00.000Z"),
+      });
+
+      act(() => result.current.goToNextMonth({ type: "click" } as any));
+      expect(result.current.monthInTheCalendar).toBe(2);
+    });
+
     it("goToPrevMonth moves backward by one month", () => {
       const { result } = renderProvider({
         defaultStartDate: new Date("2024-03-15T00:00:00.000Z"),
       });
 
       act(() => result.current.goToPrevMonth());
+      expect(result.current.monthInTheCalendar).toBe(2);
+    });
+
+    it("goToPrevMonth ignores React click events for direct onClick usage", () => {
+      const { result } = renderProvider({
+        defaultStartDate: new Date("2024-03-15T00:00:00.000Z"),
+      });
+
+      act(() => result.current.goToPrevMonth({ type: "click" } as any));
       expect(result.current.monthInTheCalendar).toBe(2);
     });
 
@@ -187,7 +220,7 @@ describe("DatePickerProvider", () => {
       });
 
       const date = new Date("2024-07-10T00:00:00.000Z");
-      act(() => result.current.handleClickSlot(date));
+      act(() => result.current.handleClickSlot!(date));
 
       expect(onChange).toHaveBeenCalledWith(date);
       expect(result.current.selectedDay).toEqual(date);
@@ -206,10 +239,10 @@ describe("DatePickerProvider", () => {
       const start = new Date("2024-07-10T00:00:00.000Z");
       const end = new Date("2024-07-20T00:00:00.000Z");
 
-      act(() => result.current.handleClickSlot(start));
+      act(() => result.current.handleClickSlot!(start));
       expect(result.current.selectedDay).toEqual([start]);
 
-      act(() => result.current.handleClickSlot(end));
+      act(() => result.current.handleClickSlot!(end));
       expect(result.current.selectedDay).toEqual([start, end]);
       expect(onChange).toHaveBeenLastCalledWith([start, end]);
     });
@@ -223,8 +256,8 @@ describe("DatePickerProvider", () => {
       const start = new Date("2024-07-20T00:00:00.000Z");
       const earlier = new Date("2024-07-10T00:00:00.000Z");
 
-      act(() => result.current.handleClickSlot(start));
-      act(() => result.current.handleClickSlot(earlier));
+      act(() => result.current.handleClickSlot!(start));
+      act(() => result.current.handleClickSlot!(earlier));
 
       expect(result.current.selectedDay).toEqual([earlier]);
     });
@@ -239,8 +272,8 @@ describe("DatePickerProvider", () => {
       const start = new Date("2024-07-20T00:00:00.000Z");
       const earlier = new Date("2024-07-10T00:00:00.000Z");
 
-      act(() => result.current.handleClickSlot(start));
-      act(() => result.current.handleClickSlot(earlier));
+      act(() => result.current.handleClickSlot!(start));
+      act(() => result.current.handleClickSlot!(earlier));
 
       expect(result.current.selectedDay).toEqual([earlier, start]);
     });
@@ -255,9 +288,9 @@ describe("DatePickerProvider", () => {
       const end = new Date("2024-07-20T00:00:00.000Z");
       const next = new Date("2024-07-25T00:00:00.000Z");
 
-      act(() => result.current.handleClickSlot(start));
-      act(() => result.current.handleClickSlot(end));
-      act(() => result.current.handleClickSlot(next));
+      act(() => result.current.handleClickSlot!(start));
+      act(() => result.current.handleClickSlot!(end));
+      act(() => result.current.handleClickSlot!(next));
 
       expect(result.current.selectedDay).toEqual([next]);
     });
@@ -273,18 +306,18 @@ describe("DatePickerProvider", () => {
       const hovered = new Date("2024-07-15T00:00:00.000Z");
 
       // no range started yet => hover ignored
-      act(() => result.current.handleHoverSlot(hovered));
+      act(() => result.current.handleHoverSlot!(hovered));
       expect(result.current.hoveredDate).toBeUndefined();
 
       // start a range, then hover is previewed
       act(() =>
-        result.current.handleClickSlot(new Date("2024-07-10T00:00:00.000Z"))
+        result.current.handleClickSlot!(new Date("2024-07-10T00:00:00.000Z"))
       );
-      act(() => result.current.handleHoverSlot(hovered));
+      act(() => result.current.handleHoverSlot!(hovered));
       expect(result.current.hoveredDate).toEqual(hovered);
 
       // clearing always works
-      act(() => result.current.handleHoverSlot(undefined));
+      act(() => result.current.handleHoverSlot!(undefined));
       expect(result.current.hoveredDate).toBeUndefined();
     });
   });
@@ -309,7 +342,7 @@ describe("DatePickerProvider", () => {
       const { result } = renderProvider({ value, onChange });
 
       const clicked = new Date("2024-07-20T00:00:00.000Z");
-      act(() => result.current.handleClickSlot(clicked));
+      act(() => result.current.handleClickSlot!(clicked));
 
       expect(onChange).toHaveBeenCalledWith(clicked);
       // selectedDay stays tied to the controlled value prop

--- a/src/DatePickerProvider.tsx
+++ b/src/DatePickerProvider.tsx
@@ -13,6 +13,9 @@ import { getAllMonths, startOfDay } from "./utils/dateUtils";
 import { normalizeTemporal } from "./utils/temporal";
 import { getTimeParts, setTimeParts, TTimeParts } from "./utils/time";
 
+const normalizeNavigationStep = (step?: unknown) =>
+  typeof step === "number" && Number.isFinite(step) ? step : 1;
+
 function DatePickerProvider<IsRange extends boolean>(
   props: TDatePickerProps<IsRange>
 ) {
@@ -154,8 +157,13 @@ function DatePickerProvider<IsRange extends boolean>(
     [currentDate, calendar, weekStartsOn]
   );
 
-  const goToNextMonth = (step = 1) => {
-    let updatedDate = addCalendarMonths(firstDayOfMonth, step, calendar);
+  const goToNextMonth = (step?: unknown) => {
+    const normalizedStep = normalizeNavigationStep(step);
+    let updatedDate = addCalendarMonths(
+      firstDayOfMonth,
+      normalizedStep,
+      calendar
+    );
 
     // Clamp to `yearRangeTo` (December of that year). Done against the target
     // rather than the current month so multi-month steps can't overshoot the
@@ -170,8 +178,13 @@ function DatePickerProvider<IsRange extends boolean>(
     setCurrentDate(updatedDate);
   };
 
-  const goToPrevMonth = (step = 1) => {
-    let updatedDate = addCalendarMonths(firstDayOfMonth, -step, calendar);
+  const goToPrevMonth = (step?: unknown) => {
+    const normalizedStep = normalizeNavigationStep(step);
+    let updatedDate = addCalendarMonths(
+      firstDayOfMonth,
+      -normalizedStep,
+      calendar
+    );
 
     // Clamp to `yearRangeFrom` (January of that year). Done against the target
     // rather than the current month so multi-month steps can't overshoot the

--- a/src/store/pickerContext.ts
+++ b/src/store/pickerContext.ts
@@ -1,19 +1,21 @@
-import { createContext } from "react";
+import { createContext, type SyntheticEvent } from "react";
 import { TDatePickerProps, TMonthListItem } from "../types";
 import { TTimeParts } from "../utils/time";
+
+export type TNavigationMonthStep = number | SyntheticEvent;
 
 export type TPickerContext<IsRange extends boolean> = {
   /**
    * Function to navigate to the next month
-   * @param step number of months to move forward (default: 1)
+   * @param step number of months to move forward (default: 1). React events are ignored for direct onClick usage.
    */
-  goToNextMonth: (step?: number) => void;
+  goToNextMonth: (step?: TNavigationMonthStep) => void;
 
   /**
    * Function to navigate to the previous month
-   * @param step number of months to move backward (default: 1)
+   * @param step number of months to move backward (default: 1). React events are ignored for direct onClick usage.
    */
-  goToPrevMonth: (step?: number) => void;
+  goToPrevMonth: (step?: TNavigationMonthStep) => void;
 
   /**
    * Function to navigate to a specific date

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "isolatedModules": true,
     "removeComments": false,
     "jsx": "react-jsx",
+    "ignoreDeprecations": "6.0",
     "downlevelIteration": true,
     "types": ["node", "jsdom", "vitest/globals", "@testing-library/jest-dom"]
   },


### PR DESCRIPTION
- ignore React click events passed to month navigation handlers
- allow direct onClick={goToPrevMonth/goToNextMonth} usage again
- document deprecated dist/styles.css import path
- add type-check script